### PR TITLE
Replaced bluebird dependency to native-or-bluebird

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,4 +1,4 @@
-var Promise = require('bluebird'),
+var Promise = require('native-or-bluebird/promise'),
     mysql = require('mysql');
 
 var connection = function(config){

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/Eventasaur/node-promise-mysql/issues"
   },
   "dependencies": {
-    "bluebird": "~2.3.10",
-    "mysql": "~2.5.2"
+    "mysql": "~2.5.2",
+    "native-or-bluebird": "^1.2.0"
   }
 }


### PR DESCRIPTION
Like native-or-bluebird says:

> The goal of this library is to be able to eventually remove this line from your code and use native Promises, allowing you to to write future-compatible code with ease. You should install bluebird in your libraries for maximum compatibility