### PR TITLE
Outdated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/Eventasaur/node-promise-mysql/issues"
   },
   "dependencies": {
-    "bluebird": "~2.3.10",
-    "mysql": "~2.5.2"
+    "bluebird": "^2.10.2",
+    "mysql": "^2.9.0"
   }
 }


### PR DESCRIPTION
Thanks for this!

The dependencies are a bit outdated and throw some notices when `npm install`-ed. 

The code seems to work fine with new versions of `mysql` and `bluebird`. Please consider publishing an updated version.

Thanks!