### PR TITLE
Fix build on Node.js v0.10.x (#12)

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,3 +1,5 @@
+var Promise = require('bluebird');
+
 var promiseCallback = function(functionName, params) {
   var self = this;
   params = Array.prototype.slice.call(params, 0);


### PR DESCRIPTION
Adds `Promise = require('bluebird');` to lib/helpers.js (#12).
This fixes the test script on Node v0.10, i.e. before `Promise` became a builtin object in Node.js (and adds the consistency of exclusively using bluebird promises).