### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+  - stable
+sudo: false
+services:
+  - mysql
+before_install:
+# use Travis CI default MySQL acount
+  - export DB_HOST=localhost
+  - export DB_USER=travis
+  - export DB_PWD=''


### PR DESCRIPTION
Fortunately, Travis CI supports MySQL out of the box, so not much configuration is required. You need to sign in on https://travis-ci.org/ using your GitHub account and enable builds for this repository (It’s been a while since I set up my first project there, but I think it did not take more than a few minutes). 

Once this PR is merged (or you push anything else to this repo), you should get something like [the overview for my fork](https://travis-ci.org/addaleax/node-promise-mysql). :)

If you want a pretty build status badge in your readme, you can use something like
`[![Build Status](https://travis-ci.org/lukeb-uk/node-promise-mysql.svg?style=flat&branch=master)](https://travis-ci.org/lukeb-uk/node-promise-mysql?branch=master)`

(And in case you are wondering: Travis CI executes `npm install` and `npm test` by default, so there’s not even any need to specify that)