### PR TITLE
add support for `AWS X-Ray` wrapped `mysql` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ pool.getConnection().then(function(connection) {
 });
 ```
 
+### Inject `mysql` module
+
+To inject an augmented `mysql` module (e.g., wrapped for tracing), an additional `mysql`
+property can be passed in as part of the `config` object. E.g., for using an
+[`AWS X-Ray` wrapped `mysql` implementation](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-sqlclients.html)
+use something like this:
+```javascript
+var AWSXRay   = require('aws-xray-sdk');
+var mysqlXRay = AWSXRay.captureMySQL(require('mysql'));
+var mysql     = require('promise-mysql');
+var connection;
+
+mysql.createConnection({
+    mysql: mysqlXRay,
+    host: 'localhost',
+    user: 'sauron',
+    password: 'theonetruering',
+    database: 'mordor'
+}).then(function(conn){
+    connection = conn;
+});
+```
+
 #### Using/Disposer Pattern with Pool
 Example implementing a using/disposer pattern using Bluebird's built-in `using` and `disposer` functions.
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -14,7 +14,8 @@ var connection = function(config, _connection){
                 self.connection = _connection;
                 resolve();
             } else {
-                self.connection = mysql.createConnection(self.config);
+                var _mysql = (self.config && self.config.mysql) || mysql;
+                self.connection = _mysql.createConnection(self.config);
                 self.connection.connect(
                     function(err){
                         if (err) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,10 +1,10 @@
-var Promise = require('bluebird'),
-    mysql = require('mysql'),
+var mysql = require('mysql'),
     Connection = require('./connection.js'),
     promiseCallback = require('./helper').promiseCallback;
 
 var pool = function(config) {
-    this.pool = mysql.createPool(config);
+    var _mysql = (config && config.mysql) || mysql;
+    this.pool = _mysql.createPool(config);
 };
 
 pool.prototype.getConnection = function getConnection() {


### PR DESCRIPTION
To inject an augmented `mysql` module (e.g., wrapped for tracing), an additional `mysql` property can be passed in as part of the `config` object. E.g., for using an [`AWS X-Ray` wrapped `mysql` implementation](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-sqlclients.html) use something like this:

```javascript
var AWSXRay   = require('aws-xray-sdk');
var mysqlXRay = AWSXRay.captureMySQL(require('mysql'));
var mysql     = require('promise-mysql');
var connection;

mysql.createConnection({
    mysql: mysqlXRay,
    host: 'localhost',
    user: 'sauron',
    password: 'theonetruering',
    database: 'mordor'
}).then(function(conn){
    connection = conn;
});
```