### PR TITLE
Allow access to the streaming query interface

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -64,6 +64,10 @@ connection.prototype.query = function(sql, values) {
     return promiseCallback.apply(this.connection, ['query', arguments]);
 };
 
+connection.prototype.queryStream = function(sql, values) {
+    return this.connection.query(sql, values);
+};
+
 connection.prototype.beginTransaction = function() {
     return promiseCallback.apply(this.connection, ['beginTransaction', arguments]);
 };


### PR DESCRIPTION
The mysqljs connection.query method, when not given a  callback function, returns an object used for the streaming interface:
https://github.com/mysqljs/mysql#streaming-query-rows

Unfortunately, this API conflicts with the promise-mysql convention of returning a promise when there is no callback function.

This solution is to reexport the original query function under the queryStream name, so it can be used when the streaming interface is desired.