### PR TITLE
Changed default error handler

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -37,10 +37,12 @@ var connection = function(config, _connection){
                 );
 
                 self.connection.on('error', function(err) {
-                    console.log('db error', err);
                     self.connection.err = err;
                     if(err.code === 'PROTOCOL_CONNECTION_LOST' || err.code === 'ECONNRESET' || err.code === 'PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR') {
+                        console.log('reconnecting to db');
                         connect();
+                    } else {
+                        console.log('db error', err);
                     }
                 });
             }


### PR DESCRIPTION
removed default console log of error and left it only for the case, when there is no reconnection after