### PR TITLE
chore(package): Move two dependencies to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "url": "https://github.com/lukeb-uk/node-promise-mysql/issues"
   },
   "dependencies": {
-    "@types/mysql": "^2.15.2",
-    "@types/bluebird": "^3.5.19",
     "bluebird": "^3.5.0",
     "mysql": "^2.14.1"
   },
   "devDependencies": {
+    "@types/mysql": "^2.15.2",
+    "@types/bluebird": "^3.5.19",
     "chai": "^4.0.1",
     "mocha": "^5.0.0"
   }


### PR DESCRIPTION
Hi, it seems you have two dependencies listed NOT as devDependencies. This is causing my lambda (serverless) package to copy types other unrelated stuff.
I hope this PR doesn't have any side-effects and can be released as a patch very soon.

Thanks!